### PR TITLE
Update msh2m_submesh.m: use tempname instead of obsolete “tmpnam” (Octave bug#59613)

### DIFF
--- a/inst/msh2m_submesh.m
+++ b/inst/msh2m_submesh.m
@@ -111,7 +111,7 @@ endfunction
 %! assert(elementlist,el);
 
 %!demo
-%! name = [tmpnam ".geo"];
+%! name = [tempname ".geo"];
 %! fid = fopen (name, "w");
 %! fputs (fid, "Point(1) = {0, 0, 0, .1};\n");
 %! fputs (fid, "Point(2) = {1, 0, 0, .1};\n");


### PR DESCRIPTION
Fix of Octave bug
https://savannah.gnu.org/bugs/?59613
Patch given by Rafael Laboissière